### PR TITLE
	isolate dukluv changes

### DIFF
--- a/duktape.cmake
+++ b/duktape.cmake
@@ -1,10 +1,16 @@
 set(DUKTAPEDIR ${CMAKE_CURRENT_LIST_DIR}/lib/duktape)
+set(DUKTAPE_MODULE_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/duktape/extras/module-duktape/)
+set(DUKTAPE_V1_COMPAT_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/duktape/extras/duk-v1-compat/)
+set(DUKTAPE_PRINT_DIR ${CMAKE_CURRENT_LIST_DIR}/lib/duktape/extras/print-alert/)
 
 include_directories(
   ${DUKTAPEDIR}/src
+  ${DUKTAPE_MODULE_DIR}
+  ${DUKTAPE_V1_COMPAT_DIR}
+  ${DUKTAPE_PRINT_DIR}
 )
 
-add_library(duktape STATIC ${DUKTAPEDIR}/src/duktape.c)
+add_library(duktape STATIC ${DUKTAPEDIR}/src/duktape.c ${DUKTAPE_MODULE_DIR}/duk_module_duktape.c ${DUKTAPE_V1_COMPAT_DIR}/duk_v1_compat.c ${DUKTAPE_PRINT_DIR}/duk_print_alert.c)
 
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   target_link_libraries(duktape

--- a/src/duv.h
+++ b/src/duv.h
@@ -3,6 +3,9 @@
 
 #include "uv.h"
 #include "duktape.h"
+#include "duk_module_duktape.h"
+#include "duk_v1_compat.h"
+#include "duk_print_alert.h"
 #include <assert.h>
 
 #if !defined(_WIN32)

--- a/src/main.c
+++ b/src/main.c
@@ -499,12 +499,14 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Problem initiailizing duktape heap\n");
     return -1;
   }
+  duk_module_duktape_init(ctx);
+  duk_print_alert_init(ctx, 0);
   loop.data = ctx;
 
   // Stash argv for later access
   duk_push_pointer(ctx, (void *) argv);
   duk_push_int(ctx, argc);
-  if (duk_safe_call(ctx, duv_stash_argv, 2, 1)) {
+  if (duk_safe_call(ctx, duv_stash_argv, NULL, 2, 1)) {
     duv_dump_error(ctx, -1);
     uv_loop_close(&loop);
     duk_destroy_heap(ctx);


### PR DESCRIPTION
build instructions:
git clone https://github.com/topcoderinc/dukluv.git
cd dukluv
git submodule init; git submodule update
cd lib
wget http://duktape.org/duktape-2.2.0.tar.xz
mv duktape duktape.old
mv duktape-2.2.0 duktape
cd ..
mkdir build
cd build
cmake ..
make

// test
cd ..
./build/dukluv test-argv.js 12 34 56

for use in external project:

add after duk_create_heap():
  duk_module_duktape_init(ctx);
  duk_print_alert_init(ctx, 0);

add include directories to build_files:
include_directories(AFTER ${EXTDIR}/dukluv/lib/duktape/extras/module-duktape/ )
include_directories(AFTER ${EXTDIR}/dukluv/lib/duktape/extras/duk-v1-compat/ )
include_directories(AFTER ${EXTDIR}/dukluv/lib/duktape/extras/print-alert/ )
